### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Ldoce MCP Server
 [![smithery badge](https://smithery.ai/badge/@edgardamasceno-dev/ldoce-mcp-server)](https://smithery.ai/server/@edgardamasceno-dev/ldoce-mcp-server)
 
+<a href="https://glama.ai/mcp/servers/@edgardamasceno-dev/ldoce-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@edgardamasceno-dev/ldoce-mcp-server/badge" alt="Longman Dictionary Server MCP server" />
+</a>
 
 Este é um MCP server desenvolvido em Node.js e TypeScript que consome a página do Longman Dictionary para uma determinada palavra e retorna os dados extraídos no formato JSON padronizado para uso por agentes de IA.
 


### PR DESCRIPTION
This PR adds a badge for the [Longman Dictionary MCP Server](https://glama.ai/mcp/servers/@edgardamasceno-dev/ldoce-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@edgardamasceno-dev/ldoce-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@edgardamasceno-dev/ldoce-mcp-server/badge" alt="Longman Dictionary Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.